### PR TITLE
Always use aggregate total for remote numbers

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "testarmada-locks",
-  "version": "1.2.2",
+  "version": "2.0.0",
   "description": "VM provisioning for automated testing",
   "main": "main.js",
   "scripts": {
@@ -14,7 +14,10 @@
     {
       "name": "Maciej Adwent",
       "url": "http://github.com/Maciek416"
-    }
+    },{
+      "name": "Dave Cadwallader",
+      "url": "http://github.com/geekdave"
+    },
   ],
   "dependencies": {
     "body-parser": "^1.14.1",

--- a/src/providers/sauce.js
+++ b/src/providers/sauce.js
@@ -75,17 +75,8 @@ module.exports = {
       if (error) {
         callback(error);
       } else {
-        // Try to get activity from the "subaccounts" structure. If sauce hasn't given us this, because
-        // this account doesn't have subaccounts, then grab from "totals" instead.
         if (data) {
-          if (data.subaccounts && data.subaccounts[settings.username]) {
-            callback(null, {
-              max: concurrency,
-              claimed: data.subaccounts[settings.username].all,
-              active: data.subaccounts[settings.username]["in progress"],
-              queued: data.subaccounts[settings.username].queued
-            });
-          } else if (data.totals) {
+          if (data.totals) {
             callback(null, {
               max: concurrency,
               claimed: data.totals.all,
@@ -93,7 +84,7 @@ module.exports = {
               queued: data.totals.queued
             });
           } else {
-            callback(new Error("Data from SauceLabs activity endpoint was invalid: no subaccount or totals field found."))
+            callback(new Error("Data from SauceLabs activity endpoint was invalid: no totals field found."))
           }
         } else {
           callback(new Error("Data from SauceLabs activity endpoint was invalid: data body is null or undefined."))


### PR DESCRIPTION
From the [API Docs](https://wiki.saucelabs.com/display/DOCS/Test+Activity+and+Usage+Methods):

> The result shows real-time numbers for the parent account and all of its sub-accounts. **There is also a "totals" section at the end which tallies the numbers across all accounts.**

This PR changes the locks behavior to always report on the aggregate VM usage across the parent account and all sub-accounts.  Previously, only the VM usage of the specified account was reported, which does not include child accounts.

In the case where sub-accounts were used by teams for automation, this was causing Locks to incorrectly think that usage was very low, causing individual tests to time out due to waiting for a VM.

/cc @Maciek416 @archlichking 