### PR TITLE
strip out dots in team names so graphite doesn't get confused

### DIFF
--- a/src/providers/sauce.js
+++ b/src/providers/sauce.js
@@ -83,6 +83,7 @@ module.exports = {
             _.each(data.subaccounts, function(val, key) {
               var countForTeam = val["in progress"];
               if (countForTeam) {
+                key = key.replace(".", "_");
                 teams[key] = countForTeam;
               }
             });


### PR DESCRIPTION
Replace dots with _s