### PR TITLE
make PORT flexible in server startup

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -6,7 +6,7 @@ marge.init(path.resolve("./locks.json"));
 var express = require("express");
 var bodyParser = require("body-parser");
 var app = express();
-var PORT = 4765;
+var PORT = process.env.PORT || 4765;
 
 log.init();
 


### PR DESCRIPTION
this'll make it so that it falls back to the defined PORT if the `process.env` `PORT` isn't available, but attempt to let the user define the `PORT`.