### PR TITLE
send accepted/rejected counts to statsd

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -19,6 +19,7 @@ app.post("/claim", function (req, res) {
   var claim = monitor.claimVM();
   if (claim) {
     console.log("<-- claim accepted from " + req.ip);
+    client.increment("accepted");
     res.send({
       accepted: true,
       token: claim.token,
@@ -26,6 +27,7 @@ app.post("/claim", function (req, res) {
     });
   } else {
     console.log("<-- claim rejected from " + req.ip);
+    client.increment("rejected");
     res.send({
       accepted: false,
       message: "Claim rejected. No VMs available."


### PR DESCRIPTION
so that we can get real-time info about the number of accepted and rejected claims within a bucket of time (10 sec resolution)

useful for tracking how accurate locks is for throttling back usage during peak times

/cc @Maciek416 @archlichking @ThaiWood @chaseadamsio 