### PR TITLE
High Performance Websocket API

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,7 @@ Locks is a virtual machine traffic control service for SauceLabs users.
 
 It ensures a test is never waiting to acquire a virtual machine. This allows orchestration software to avoid killing tests early for reasons unrelated to failure (i.e. a test should never be punished for running too long if it was merely waiting for a VM to become available).
 
-Coming soon: 
-  * Remote API + installation instructions.
-  * Prioritization ("skip the line")
-  * Automatic worker count suggestions
-
-# Startup
+## Startup
 
 ```
 export SAUCE_ACCESS_KEY='xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'
@@ -19,5 +14,50 @@ export SAUCE_USERNAME='xxxxxxxxxxxx'
 export LOCKS_STATSD_URL=hostname.of.statsd.server.com
 export LOCKS_STATSD_PREFIX=locks
 
+# optionally configure locks' listener port (default 4765)
+export LOCKS_PORT=4567
+
 forever start /path/to/locks/src/server.js
+```
+
+## Websocket API
+
+### Claiming VMs
+
+Send the following to `locks` to attempt to claim a VM:
+
+```json
+{
+  "type": "claim"
+}
+```
+
+If `locks` accepts your claim, you will eventually receive the following message:
+
+```json
+{
+  "accepted": true,
+  "token": <string>
+}
+```
+
+The `locks` websocket API will always try to satisfy as many claims as you've recently made until it runs out of capacity. If this happens, your client will receive a rejection. If a claim is rejected, the return message will look like this:
+
+```json
+{
+  "accepted": false
+}
+```
+
+If your claim is rejected, `locks` is no longer attempting to claim a VM for you, and your client must poll again.
+
+### Releasing VMs (OPTIONAL)
+
+To more accurately track VM supply, your client can send a courtesy message informing `locks` that you are no longer using a recently-claimed VM. Simply send a release message along with the token of the claim. Note that this is a safe operation even if `locks` has already expired the corresponding claim token.
+
+```json
+{
+  "type": "release",
+  "token": <string>
+}
 ```

--- a/package.json
+++ b/package.json
@@ -23,10 +23,10 @@
   "dependencies": {
     "body-parser": "^1.14.1",
     "express": "^4.13.3",
-    "lodash": "^4.6.1",
-    "marge": "^1.0.1",
     "hot-shots": "^4.3.0",
-    "request": "^2.63.0"
+    "lodash": "^4.6.1",
+    "request": "^2.63.0",
+    "ws": "^2.2.3"
   },
   "license": "MIT",
   "bugs": {

--- a/src/log.js
+++ b/src/log.js
@@ -1,5 +1,4 @@
 var request = require("request");
-var argv = require("marge").argv;
 var path = require("path");
 var fs = require("fs");
 const SDC = require("hot-shots");
@@ -34,9 +33,11 @@ var init = function () {
 };
 
 var sendStats = function (type, metricName, value, tags) {
-  var tagStr = tags ? JSON.stringify(tags) : "";
-  console.log("[" + type + "] " + metricName + " : " + value + " " + tagStr);
-  client[type](metricName, value, tags);
+  if (client) {
+    var tagStr = tags ? JSON.stringify(tags) : "";
+    console.log("[" + type + "] " + metricName + " : " + value + " " + tagStr);
+    client[type](metricName, value, tags);
+  }
 };
 
 var gauge = function(metricName, value, tags) {

--- a/src/restapi.js
+++ b/src/restapi.js
@@ -1,0 +1,51 @@
+var log = require("./log");
+
+module.exports = function (app, monitor) {
+
+  app.post("/claim", function (req, res) {
+    var claim = monitor.claimVM();
+    if (claim) {
+      log.increment("accepted");
+      res.send({
+        accepted: true,
+        token: claim.token,
+        message: "Claim accepted"
+      });
+    } else {
+      log.increment("rejected");
+      res.send({
+        accepted: false,
+        message: "Claim rejected. No VMs available."
+      });
+    }
+  });
+
+  app.post("/release", function (req, res) {
+    if (req.body) {
+      var token = req.body.token;
+      if (monitor.releaseVM(token)) {
+        log.increment("released");
+      } else {
+        log.increment("ignored");
+      }
+    } else {
+      log.increment("invalid");
+    }
+  });
+
+  app.post("/timeout", function (req, res) {
+    if (req.body) {
+      var claimTimeout = req.body.timeout;
+      res.send(monitor.setClaimTimeout(claimTimeout));
+    }
+  });
+
+  app.get("/status", function (req, res) {
+    res.send(monitor.getStatus());
+  });
+
+  app.get("/history", function (req, res) {
+    res.send(monitor.getHistory());
+  });
+
+};

--- a/src/server.js
+++ b/src/server.js
@@ -1,12 +1,14 @@
-var marge = require("marge");
 var path = require("path");
 var log = require("./log");
-marge.init(path.resolve("./locks.json"));
 
 var express = require("express");
 var bodyParser = require("body-parser");
+
+var createRESTAPI = require("./restapi");
+var createSocketAPI = require("./socketapi");
+
 var app = express();
-var PORT = 4765;
+var PORT = process.env.LOCKS_PORT || 4765;
 
 log.init();
 
@@ -15,58 +17,18 @@ app.use(bodyParser.urlencoded({ extended: true }));
 
 var monitor = require("./monitor");
 
-app.post("/claim", function (req, res) {
-  var claim = monitor.claimVM();
-  if (claim) {
-    log.increment("accepted");
-    res.send({
-      accepted: true,
-      token: claim.token,
-      message: "Claim accepted"
-    });
-  } else {
-    log.increment("rejected");
-    res.send({
-      accepted: false,
-      message: "Claim rejected. No VMs available."
-    });
-  }
-});
-
-app.post("/release", function (req, res) {
-  if (req.body) {
-    var token = req.body.token;
-    if (monitor.releaseVM(token)) {
-      log.increment("released");
-    } else {
-      log.increment("ignored");
-    }
-  } else {
-    log.increment("invalid");
-  }
-});
-
-app.post("/timeout", function (req, res) {
-  if (req.body) {
-    var claimTimeout = req.body.timeout;
-    res.send(monitor.setClaimTimeout(claimTimeout));
-  }
-});
-
-app.get("/status", function (req, res) {
-  res.send(monitor.getStatus());
-});
-
-app.get("/history", function (req, res) {
-  res.send(monitor.getHistory());
-});
-
 monitor.initialize(function () {
   console.log("Starting HTTP server..");
+
+  createRESTAPI(app, monitor);
+
   var server = app.listen(PORT, function () {
     var host = server.address().address;
     var port = server.address().port;
 
+    createSocketAPI(server, monitor);
+
     console.log("locks HTTP server started at http://%s:%s", host, port);
   });
 });
+

--- a/src/socketapi.js
+++ b/src/socketapi.js
@@ -1,0 +1,42 @@
+var WebSocketServer = require("ws").Server;
+var log = require("./log");
+
+module.exports = function (server, monitor) {
+  var wss = new WebSocketServer({
+    server: server
+  });
+
+  wss.on("connection", function (ws) {
+    ws.on("message", function (message) {
+      message = JSON.parse(message);
+
+      switch (message.type) {
+
+        case "claim":
+          const claim = monitor.claimVM();
+          if (claim) {
+            log.increment("accepted");
+            ws.send(JSON.stringify({
+              accepted: true,
+              token: claim.token
+            }));
+          } else {
+            log.increment("rejected");
+            ws.send(JSON.stringify({
+              accepted: false
+            }));
+          }
+          break;
+
+        case "release":
+          const token = message.token;
+          if (monitor.releaseVM(token)) {
+            log.increment("released");
+          } else {
+            log.increment("ignored");
+          }
+          break;
+      }
+    });
+  });
+};


### PR DESCRIPTION
This PR adds a websocket API to `locks` for `claim` and `release`.

## Changes

### Primary

- Add websocket endpoint for claim and release (`src/socketapi.js`). Adds `ws` dependency.
- Move REST api to `src/restapi.js`
- Websocket API documentation in README

### Secondary/Cosmetic

- Add LOCKS_PORT configuration option, and document
- Remove "coming soon" section from README
- Remove `marge` usage and dependency -- marge and argv are unused anywhere in the project

/cc @archlichking @geekdave 