### PR TITLE
Make locks a globally-installable npm module

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,7 @@
 FROM node
 
-RUN git clone --recursive git://github.com/TestArmada/locks.git /app \
-&& cd /app \
-&& npm i 
+RUN npm install -g testarmada-locks
 
 EXPOSE 4765
 
-CMD node /app/src/server.js
+CMD locks

--- a/README.md
+++ b/README.md
@@ -4,6 +4,16 @@ Locks is a virtual machine traffic control service for SauceLabs users.
 
 It ensures a test is never waiting to acquire a virtual machine. This allows orchestration software to avoid killing tests early for reasons unrelated to failure (i.e. a test should never be punished for running too long if it was merely waiting for a VM to become available).
 
+## Installing
+
+The preferred method for installing `locks` is as a global module:
+
+```
+npm install -g testarmada-locks
+```
+
+## Running
+
 ```
 export SAUCE_ACCESS_KEY='xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'
 export SAUCE_USERNAME='xxxxxxxxxxxx'
@@ -15,11 +25,12 @@ export LOCKS_STATSD_PREFIX=locks
 # optionally configure locks' listener port (default 4765)
 export LOCKS_PORT=4567
 
-forever start /path/to/locks/src/server.js
+locks
 ```
 
+## Running with Docker
 
-## Using Docker
+Check out our Dockerfile [here](./Dockerfile)
 
 ```
 # docker build . -t testarmada/locks
@@ -34,6 +45,8 @@ forever start /path/to/locks/src/server.js
 ```
 
 ## Websocket API
+
+To communicate with `locks`, open a websocket to your locks URL and use the claim and release API, outlined below:
 
 ### Claiming VMs
 

--- a/bin/locks
+++ b/bin/locks
@@ -1,0 +1,3 @@
+#!/usr/bin/env node
+
+require("../src/server.js");

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "testarmada-locks",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "description": "VM provisioning for automated testing",
   "main": "main.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,8 +1,11 @@
 {
   "name": "testarmada-locks",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "VM provisioning for automated testing",
   "main": "main.js",
+  "bin": {
+    "locks": "./bin/locks"
+  },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },


### PR DESCRIPTION
This PR:

  - Exposes a `locks` binary via package.json which is available as a CLI command when `locks` is installed via `npm install -g`
  - Updates the `README` to indicate:
    - `npm install -g` is the recommended way to install
    - how to run using this new way
    - remove possibly-confusing reference to `forever` (users should figure out their own "backgrounding" method ideally)
  - Updates `Dockerfile` to reflect new installation method and run method
  - Adds a link to `Dockerfile` from README
  - Clarifies some language in the README

/cc @ThaiWood @archlichking @geekdave 